### PR TITLE
Set environment variables in tox for headless SDL.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,3 +13,6 @@ deps = -rrequirements.dev.txt
 commands =
     #pylint --rcfile=setup.cfg stuntcat
     pytest tests
+setenv =
+    SDL_VIDEODRIVER=dummy
+    SDL_AUDIODRIVER=disk


### PR DESCRIPTION
Looks like I reverted this commit too.