### PR TITLE
Installing cx_freeze that way didn't work on win.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Tests are run on mac, linux, windows when there is a pull request made.
 
 ### releasing
 
+Releasing is tested with python3.7(not python2 or any other version).
+
 To the python package index (pypi).
 ```
 rm -rf dist/*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,10 @@ environment:
       PYTHON_VERSION: "3.7.0"
       PYTHON_ARCH: "64"
 
-    - TOXENV: py27
-      PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.0"
-      PYTHON_ARCH: "32"
+    # - TOXENV: py27
+    #   PYTHON: "C:\\Python27"
+    #   PYTHON_VERSION: "2.7.0"
+    #   PYTHON_ARCH: "32"
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
@@ -19,8 +19,31 @@ init:
 # tox installs stuff itself.
 install:
   # We need wheel installed to build wheels
-  # - "%PYTHON%\\python.exe -m pip install -r requirements.dev.txt"
-  - "%PYTHON%\\python.exe -m pip install tox"
+  - "%PYTHON%\\python.exe -m pip install -r requirements.dev.txt"
+  - "%PYTHON%\\python.exe setup.py bdist_msi"
 
 test_script:
   - "%PYTHON%\\python.exe -m tox"
+
+# https://www.appveyor.com/docs/packaging-artifacts/
+artifacts:
+  - path: dist\*.msi
+    name: windows msi executable
+
+# For uploading releases to github.
+# https://www.appveyor.com/docs/deployment/github/
+deploy:
+  release: stuntcat-v$(appveyor_build_version)
+  description: 'A stuntcat draft release'
+  provider: GitHub
+  auth_token:
+    secure: AEkY1NaqqAq8NhWj7xNY+meHJINhLrnHNpwEeVtKBsAhdxo7u34gNsTH+KcYJUho # your encrypted token from GitHub
+  artifact: /dist\.*\.msi/            # upload all NuGet packages to release assets
+  draft: true
+  prerelease: false
+  on:
+    branch: master                 # release from master branch only
+    appveyor_repo_tag: true        # deploy on tag push only
+
+
+

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -11,4 +11,5 @@ twine
 wheel
 # cx_freeze at time of writing does not support python3.7 in a release.
 https://codeload.github.com/anthony-tuininga/cx_Freeze/zip/master ; python_version == "3.7"
+cx_freeze ; python_version == "2.7"
 -r requirements.txt

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -9,6 +9,6 @@ pytest-pylint
 tox
 twine
 wheel
--e 'git+https://github.com/anthony-tuininga/cx_Freeze.git#egg=cx_freeze ; sys.platform == "darwin" and python_version == "3.7"'
-cx_freeze ; python_version < '3.7'
+# cx_freeze at time of writing does not support python3.7 in a release.
+https://codeload.github.com/anthony-tuininga/cx_Freeze/zip/master ; python_version == "3.7"
 -r requirements.txt


### PR DESCRIPTION
When running bdist_msi, cx_freeze didn't work with the way it was installed (using a `-e git+` line in requirements.dev.txt).

For: https://github.com/pygame/stuntcat/issues/16