### PR TITLE
publish fix3

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.x'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/stuntcat/__init__.py
+++ b/stuntcat/__init__.py
@@ -1,7 +1,7 @@
 """
 Stuntcat the game
 """
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 from stuntcat import game
 


### PR DESCRIPTION
- github: Use python 3.11, because python 3.12 breaks pymunk
- v0.2.4
